### PR TITLE
performance optimization in nearest neighbor search

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -80,7 +80,7 @@ function findWinner(cod, sampl)
 
     for i in 1:n
 
-        d = euclidean(sampl, cod[i,:])
+        d = sqeuclidean(sampl, cod[i,:])
         if (d < dist)
             dist = d
             winner = i


### PR DESCRIPTION
`sqeuclidian` is faster than `euclidian` because it skips the square root step. Since a < b => a^2 < b^2, we can also find the winner by minimizing the square of the distance.